### PR TITLE
Keep the locale related authNotes through the IdentityBroker flow. (#…

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -45,6 +45,7 @@ import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
+import org.keycloak.locale.LocaleSelectorProvider;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.AuthenticationFlowModel;
@@ -115,6 +116,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -576,8 +578,11 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             logger.debug("Redirecting to flow for firstBrokerLogin");
 
             boolean forwardedPassiveLogin = "true".equals(authenticationSession.getAuthNote(AuthenticationProcessor.FORWARDED_PASSIVE_LOGIN));
+
+            Map<String, String> extractedAuthNotes = extractAuthNotesFromSession(authenticationSession);
             // Redirect to firstBrokerLogin after successful login and ensure that previous authentication state removed
             AuthenticationProcessor.resetFlow(authenticationSession, LoginActionsService.FIRST_BROKER_LOGIN_PATH);
+            extractedAuthNotes.forEach(authenticationSession::setAuthNote);
 
             // Set the FORWARDED_PASSIVE_LOGIN note (if needed) after resetting the session so it is not lost.
             if (forwardedPassiveLogin) {
@@ -608,6 +613,18 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
             return finishOrRedirectToPostBrokerLogin(authenticationSession, context, false);
         }
+    }
+
+    private Map<String, String> extractAuthNotesFromSession(AuthenticationSessionModel authenticationSession) {
+        return Stream.of(
+            LocaleSelectorProvider.USER_REQUEST_LOCALE,
+            LocaleSelectorProvider.CLIENT_REQUEST_LOCALE
+        )
+            .filter(it -> authenticationSession.getAuthNote(it) != null)
+            .collect(Collectors.toMap(
+                Function.identity(),
+                authenticationSession::getAuthNote
+            ));
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerConfiguration.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.keycloak.testsuite.broker.BrokerTestConstants.*;
 import static org.keycloak.testsuite.broker.BrokerTestTools.*;
@@ -44,6 +45,8 @@ public class KcOidcBrokerConfiguration implements BrokerConfiguration {
         realm.setEnabled(true);
         realm.setEventsListeners(Arrays.asList("jboss-logging", "event-queue"));
         realm.setEventsEnabled(true);
+        realm.setInternationalizationEnabled(true);
+        realm.setSupportedLocales(Set.of("en", "hu"));
 
         return realm;
     }
@@ -56,6 +59,8 @@ public class KcOidcBrokerConfiguration implements BrokerConfiguration {
         realm.setResetPasswordAllowed(true);
         realm.setEventsListeners(Arrays.asList("jboss-logging", "event-queue"));
         realm.setEventsEnabled(true);
+        realm.setInternationalizationEnabled(true);
+        realm.setSupportedLocales(Set.of("en", "hu"));
 
         return realm;
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesWithIdpHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesWithIdpHintTest.java
@@ -1,0 +1,87 @@
+package org.keycloak.testsuite.broker;
+
+import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.pages.PageUtils;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static java.util.Locale.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.keycloak.OAuth2Constants.*;
+import static org.keycloak.testsuite.broker.BrokerTestConstants.*;
+import static org.keycloak.testsuite.broker.BrokerTestTools.*;
+
+public class KcOidcBrokerUiLocalesWithIdpHintTest extends AbstractBrokerTest {
+
+    private static final Locale HUNGARIAN = Locale.forLanguageTag("hu");
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return new KcOidcBrokerConfigurationWithUiLocalesEnabled();
+    }
+
+    private class KcOidcBrokerConfigurationWithUiLocalesEnabled extends KcOidcBrokerConfiguration {
+
+        @Override
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
+            IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
+            Map<String, String> config = idp.getConfig();
+            applyDefaultConfiguration(config, syncMode);
+            config.put("uiLocales", "true");
+            return idp;
+        }
+    }
+
+    @Override
+    protected void loginUser() {
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
+
+        driver.navigate().to(driver.getCurrentUrl() + "&ui_locales=hu&kc_idp_hint=kc-oidc-idp");
+
+        waitForPage(driver, "belépés ide", true); // sign in to
+
+        Assert.assertThat("Driver should be on the provider realm page right now",
+                driver.getCurrentUrl(), containsString("/auth/realms/" + bc.providerRealmName() + "/"));
+
+        Assert.assertThat(UI_LOCALES_PARAM + "=" + HUNGARIAN.toLanguageTag() + " should be part of the url",
+            driver.getCurrentUrl(), containsString(UI_LOCALES_PARAM + "=" + HUNGARIAN.toLanguageTag()));
+        Assert.assertThat("The provider realm should be in Hungarian because the ui_locales is passed",
+            driver.getPageSource(), containsString("Jelentkezzen be a fiókjába")); // Sign in to your account
+
+        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+        waitForPage(driver, "felhasználói fiók adatok módosítása", false); // update account information
+
+        Assert.assertThat("The consumer realm should be in Hungarian even after the redirect from the IDP.",
+                driver.getPageSource(), containsString("Felhasználói fiók adatok módosítása"));// update account information
+
+        Assert.assertThat("We must be on correct realm right now",
+                driver.getCurrentUrl(), containsString("/auth/realms/" + bc.consumerRealmName() + "/"));
+
+        log.debug("Updating info on updateAccount page");
+        updateAccountInformationPage.updateAccountInformation(bc.getUserLogin(), bc.getUserEmail(), "Firstname", "Lastname");
+
+        UsersResource consumerUsers = adminClient.realm(bc.consumerRealmName()).users();
+
+        int userCount = consumerUsers.count();
+        Assert.assertTrue("There must be at least one user", userCount > 0);
+
+        List<UserRepresentation> users = consumerUsers.search("", 0, userCount);
+
+        boolean isUserFound = false;
+        for (UserRepresentation user : users) {
+            if (user.getUsername().equals(bc.getUserLogin()) && user.getEmail().equals(bc.getUserEmail())) {
+                isUserFound = true;
+                break;
+            }
+        }
+
+        Assert.assertTrue("There must be user " + bc.getUserLogin() + " in realm " + bc.consumerRealmName(),
+                isUserFound);
+    }
+}


### PR DESCRIPTION
…10444)

Closes #8827

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Helps to overcome issues like:

HP-1443 Kieliasetukset - Vahvista sähköpostisi viesti tulee sähköpostiin englannin kielellä vaikka FI valittuna
HP-1283 Kieli vaihtuu kesken kirjautumispolun profiilia luodessa
HP-1483 Kieliasetukset - EN valittu ja logoutin jälkeen tuleva sivu on Suomeksi
